### PR TITLE
Make use of functional operators to clean up some code

### DIFF
--- a/BuildStatusChecker/Sources/BuildStatusChecker/API/Bitrise/BitriseAPI.swift
+++ b/BuildStatusChecker/Sources/BuildStatusChecker/API/Bitrise/BitriseAPI.swift
@@ -43,9 +43,7 @@ extension BitriseAPI {
         jsonDecoder.dateDecodingStrategy = .iso8601
 
         let publisher = URLSession.shared.dataTaskPublisher(for: urlRequest)
-        .map {
-            return $0.data
-        }
+        .map { $0.data }
         .decode(type: BitriseBuilds.self, decoder: jsonDecoder)
 
         return publisher

--- a/BuildStatusChecker/Sources/BuildStatusChecker/API/Bitrise/BitriseBuilds.swift
+++ b/BuildStatusChecker/Sources/BuildStatusChecker/API/Bitrise/BitriseBuilds.swift
@@ -9,25 +9,13 @@ public struct BitriseBuilds: Codable {
 // MARK: - Helpers
 extension BitriseBuilds {
     func contains(branch: Branch) -> Bool {
-        for build in data {
-            if build.branch == branch { return true }
-        }
-
-        return false
+        return data.contains(where: { $0.branch == branch })
     }
 
     func latestBuild(for branch: Branch) -> BitriseBuild? {
-        var result: BitriseBuild?
-
-        for build in data where build.branch == branch {
-            if let newestBuild = result, build.startedOnWorkerAt > newestBuild.startedOnWorkerAt {
-                result = build
-            }
-            else if result == nil {
-                result = build
-            }
-        }
-
-        return result
+        return data
+            .filter { $0.branch == branch }
+            .sorted(by: { $0.startedOnWorkerAt > $1.startedOnWorkerAt })
+            .first
     }
 }

--- a/BuildStatusChecker/Sources/BuildStatusChecker/API/Bitrise/BitriseConfiguration.swift
+++ b/BuildStatusChecker/Sources/BuildStatusChecker/API/Bitrise/BitriseConfiguration.swift
@@ -12,7 +12,7 @@ class BitriseConfiguration {
     }()
 
     public var isComplete: Bool {
-         return [authToken, baseUrl, appSlug]
+         return ![authToken, baseUrl, appSlug]
             .map { $0.isEmpty }
             .contains(true)
     }

--- a/BuildStatusChecker/Sources/BuildStatusChecker/API/Bitrise/BitriseConfiguration.swift
+++ b/BuildStatusChecker/Sources/BuildStatusChecker/API/Bitrise/BitriseConfiguration.swift
@@ -12,6 +12,8 @@ class BitriseConfiguration {
     }()
 
     public var isComplete: Bool {
-        return !authToken.isEmpty && !baseUrl.isEmpty && !appSlug.isEmpty
+         return [authToken, baseUrl, appSlug]
+            .map { $0.isEmpty }
+            .contains(true)
     }
 }

--- a/Lumina/Modules/BuildMonitor/View/BuildMonitorView.swift
+++ b/Lumina/Modules/BuildMonitor/View/BuildMonitorView.swift
@@ -17,25 +17,12 @@ struct BuildMonitorView: View {
                     ProgressIndicatorView()
                 }
 
-                if viewModel.errorMessage != nil {
-                    ErrorView(message: viewModel.errorMessage!)
-                }
-
-                if viewModel.development != nil {
-                    BuildView(viewModel: BuildViewModel(from: viewModel.development!))
-                }
-
-                if viewModel.master != nil {
-                    BuildView(viewModel: BuildViewModel(from: viewModel.master!))
-                }
-
-                if viewModel.release != nil {
-                    BuildView(viewModel: BuildViewModel(from: viewModel.release!))
-                }
-
-                if viewModel.hotfix != nil {
-                    BuildView(viewModel: BuildViewModel(from: viewModel.hotfix!))
-                }
+                viewModel.errorMessage.map { ErrorView(message: $0) }
+               
+                viewModel.development.map { BuildView(viewModel: BuildViewModel(from: $0)) }
+                viewModel.master.map { BuildView(viewModel: BuildViewModel(from: $0)) }
+                viewModel.release.map { BuildView(viewModel: BuildViewModel(from: $0)) }
+                viewModel.hotfix.map { BuildView(viewModel: BuildViewModel(from: $0)) }
 
                 ForEach(viewModel.feature, id: \.self) { featureBuild in
                     BuildView(viewModel: BuildViewModel(from: featureBuild))

--- a/Lumina/Modules/StatusItem/StatusItemView.swift
+++ b/Lumina/Modules/StatusItem/StatusItemView.swift
@@ -24,20 +24,9 @@ class StatusItemView: NSObject {
     func update() {
         statusItem.menu = NSMenu()
 
-        if let master = viewModel.master {
-            statusItem.menu?.addItem(statusItem(for: master))
-        }
-
-        if let develop = viewModel.development {
-            statusItem.menu?.addItem(statusItem(for: develop))
-        }
-
-        if let release = viewModel.release {
-            statusItem.menu?.addItem(statusItem(for: release))
-        }
-
-        if let hotfix = viewModel.hotfix {
-            statusItem.menu?.addItem(statusItem(for: hotfix))
+        let branches = [viewModel.master, viewModel.development, viewModel.release, viewModel.hotfix]
+        for case let branch? in branches {
+             statusItem.menu?.addItem(statusItem(for: branch))
         }
 
         statusItem.menu?.addItem(NSMenuItem.separator())


### PR DESCRIPTION
This PR introduces some functional programming paradigms in order to reduce some unnecessary lines of code. Let me know what you think. If you want to discard this PR because of decreased readability this would be totally fine :)

However I highly encourage you to have a look at BuildMonitorView.swift.
Instead of checking for 
`if let myVariable == nil {
    //render SwiftUI view
}
` 
you can in fact use map to do the same. But this way you do not need to force unwrap the non-nil variable.