### PR TITLE
Error handling

### DIFF
--- a/BuildStatusChecker/Sources/BuildStatusChecker/API/Bitrise/BitriseBranches.swift
+++ b/BuildStatusChecker/Sources/BuildStatusChecker/API/Bitrise/BitriseBranches.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 public struct BitriseBranches: Codable {
     public let data: [String]
@@ -22,7 +23,12 @@ extension BitriseBranches {
 extension BitriseBranches {
     func hasVersionPostfix(branchName: String) -> Bool {
         let range = NSRange(location: 0, length: branchName.utf16.count)
-        let regex = try! NSRegularExpression(pattern: "[a-zA-Z]/\\d+.\\d+.\\d+")
-        return regex.firstMatch(in: branchName, options: [], range: range) != nil
+        do {
+            let regex = try NSRegularExpression(pattern: "[a-zA-Z]/\\d+.\\d+.\\d+")
+            return regex.firstMatch(in: branchName, options: [], range: range) != nil
+        } catch {
+            os_log("Error building the regualar expression: %{PUBLIC}@", log: OSLog.buildFetcher, type: .error, error.localizedDescription)
+            return false
+        }
     }
 }

--- a/BuildStatusChecker/Sources/BuildStatusChecker/API/Bitrise/BitriseBuildFetcher.swift
+++ b/BuildStatusChecker/Sources/BuildStatusChecker/API/Bitrise/BitriseBuildFetcher.swift
@@ -50,7 +50,7 @@ extension BitriseBuildFetcher: BuildFetcher {
             switch compl {
                 case .finished: os_log("getRecentBuilds finished", log: OSLog.buildFetcher, type: .debug)
                 case .failure(let error):
-                    os_log("getRecentBuilds finished with error: %{PUBLIC}@", log: OSLog.buildFetcher, type: .error)
+                    os_log("getRecentBuilds finished with error: %{PUBLIC}@", log: OSLog.buildFetcher, type: .error, error.localizedDescription)
                     completion(.failure(error))
             }
         }, receiveValue: { (bitriseBuilds) in


### PR DESCRIPTION
This PR introduces some minor changes to the current error handling.
1. The app does not crash when creating an invalid regex but instead prints an error message to the console
2. The already logged error message for getRecentBuilds now includes the error parameter.