### PR TITLE
Reset timer on manual refresh

### DIFF
--- a/Lumina/Model/BuildMonitorModel.swift
+++ b/Lumina/Model/BuildMonitorModel.swift
@@ -13,7 +13,7 @@ extension BuildMonitorModel {
         fetchBuilds()
 
         let interval = TimeInterval(SettingsStore().readUpdateInterval())
-        self.updateTimer = Timer.scheduledTimer(timeInterval: interval, target: self, selector: #selector(self.requestUpdate), userInfo: nil, repeats: true)
+        self.updateTimer = Timer.scheduledTimer(timeInterval: interval, target: self, selector: #selector(fetchBuilds), userInfo: nil, repeats: true)
     }
 }
 
@@ -57,10 +57,11 @@ extension BuildMonitorModel {
 // MARK: - Update mechanism
 extension BuildMonitorModel {
     @objc func requestUpdate() {
-        fetchBuilds()
+        updateTimer?.invalidate()
+        startUpdating()
     }
 
-    private func fetchBuilds() {
+    @objc private func fetchBuilds() {
         notifyStartedLoading()
         buildFetcher.getRecentBuilds() { result in
             switch result {

--- a/Lumina/Model/BuildMonitorModel.swift
+++ b/Lumina/Model/BuildMonitorModel.swift
@@ -1,9 +1,10 @@
 import Foundation
 import BuildStatusChecker
+import Combine
 
 class BuildMonitorModel {
     private var buildFetcher = BuildFetcherFactory.createBuildFetcher()
-    private var updateTimer: Timer?
+    private var timerToken: AnyCancellable?
     private var observers: [ModelObserver] = []
 }
 
@@ -13,7 +14,10 @@ extension BuildMonitorModel {
         fetchBuilds()
 
         let interval = TimeInterval(SettingsStore().readUpdateInterval())
-        self.updateTimer = Timer.scheduledTimer(timeInterval: interval, target: self, selector: #selector(fetchBuilds), userInfo: nil, repeats: true)
+        let timer = Timer.publish(every: interval, on: .main, in: .common).autoconnect()
+        self.timerToken = timer.sink(receiveValue: {[weak self] _ in
+            self?.fetchBuilds()
+        })
     }
 }
 
@@ -57,7 +61,7 @@ extension BuildMonitorModel {
 // MARK: - Update mechanism
 extension BuildMonitorModel {
     @objc func requestUpdate() {
-        updateTimer?.invalidate()
+        timerToken?.cancel()
         startUpdating()
     }
 


### PR DESCRIPTION
When the timer triggers a refresh the builds are fetched.
When a manual refresh is triggered the timer is stopped, the builds are fetched and the timer is started again.

Fixes #1.