### PR TITLE
Statusmenu options

### DIFF
--- a/Lumina/App/AppCoordinator.swift
+++ b/Lumina/App/AppCoordinator.swift
@@ -23,21 +23,27 @@ class AppCoordinator: NSObject {
 // MARK: - Starting the app
 extension AppCoordinator {
     func start() {
-        let contentView = BuildMonitorView(viewModel: BuildMonitorViewModel(model: buildMonitorModel))
+        if buildMonitorWindow == nil {
+            let contentView = BuildMonitorView(viewModel: BuildMonitorViewModel(model: buildMonitorModel))
 
-        buildMonitorWindow = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 600),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
-            backing: .buffered, defer: false)
-        buildMonitorWindow?.center()
-        buildMonitorWindow?.title = "Lumina"
-        buildMonitorWindow?.setFrameAutosaveName("Main Window")
-        buildMonitorWindow?.contentView = NSHostingView(rootView: contentView)
-        buildMonitorWindow?.makeKeyAndOrderFront(nil)
+            buildMonitorWindow = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 480, height: 600),
+                styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+                backing: .buffered, defer: false)
+            buildMonitorWindow?.center()
+            buildMonitorWindow?.title = "Lumina"
+            buildMonitorWindow?.setFrameAutosaveName("Main Window")
+            buildMonitorWindow?.contentView = NSHostingView(rootView: contentView)
+            buildMonitorWindow?.isReleasedWhenClosed = false
+            buildMonitorWindow?.makeKeyAndOrderFront(nil)
 
-        buildMonitorModel.startUpdating()
+            buildMonitorModel.startUpdating()
+        } else {
+            NSApp.activate(ignoringOtherApps: true)
+        }
     }
 }
+
 
 // MARK: - Updating
 extension AppCoordinator {

--- a/Lumina/AppDelegate.swift
+++ b/Lumina/AppDelegate.swift
@@ -32,4 +32,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         appCoordinator?.start()
     }
 
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if flag {
+            return false
+        } else {
+            openMainWindow(self)
+            return true
+        }
+    }
 }

--- a/Lumina/AppDelegate.swift
+++ b/Lumina/AppDelegate.swift
@@ -27,4 +27,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBAction func openPreferences(_ sender: Any) {
         appCoordinator?.openPreferences()
     }
+    
+    @IBAction func openMainWindow(_ sender: Any) {
+        appCoordinator?.start()
+    }
+
 }

--- a/Lumina/Modules/StatusItem/StatusItemView.swift
+++ b/Lumina/Modules/StatusItem/StatusItemView.swift
@@ -18,7 +18,7 @@ class StatusItemView: NSObject {
         statusItem.button?.title = viewModel.title
         statusItem.button?.image =  NSImage(imageLiteralResourceName: "StatusBarButtonImage")
         statusItem.menu = NSMenu()
-        statusItem.menu?.addItem(withTitle: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        addDefaultMenuItems()
     }
 
     func update() {
@@ -35,11 +35,18 @@ class StatusItemView: NSObject {
             statusItem.menu?.addItem(statusItem(for: featureBuild))
         }
 
+        addDefaultMenuItems()
+    }
+    
+    private func addDefaultMenuItems() {
+        statusItem.menu?.addItem(NSMenuItem.separator())
+        statusItem.menu?.addItem(withTitle: "Open Main Window...", action: #selector(AppDelegate.openMainWindow(_:)), keyEquivalent: "")
+        statusItem.menu?.addItem(withTitle: "Preferences...", action: #selector(AppDelegate.openPreferences(_:)), keyEquivalent: ",")
         statusItem.menu?.addItem(NSMenuItem.separator())
         statusItem.menu?.addItem(withTitle: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
     }
 
-    @objc func printTest(sender: Any) {
+    @objc func openInBrowser(sender: Any) {
         if let item = sender as? NSMenuItem, let build = viewModel.build(for: item.title) {
             viewModel.openInBrowser(build: build)
         }
@@ -50,7 +57,7 @@ class StatusItemView: NSObject {
 extension StatusItemView {
     func statusItem(for build: Build) -> NSMenuItem {
         let attributedTitle = NSAttributedString(string: build.branch, attributes: viewModel.attributes(for: build.status))
-        let menuItem = NSMenuItem(title: build.branch, action: #selector(printTest(sender:)), keyEquivalent: "")
+        let menuItem = NSMenuItem(title: build.branch, action: #selector(openInBrowser(sender:)), keyEquivalent: "")
         menuItem.attributedTitle = attributedTitle
         menuItem.target = self
 


### PR DESCRIPTION
Fixes #5.

Adds "Preferences" and "Open Main Window" options to the statusbar menu.

1. "Preferences" opens the preferences window
2. "Open Main Window" opens the main window if not opened yet, if the window is opened already it brings the window to the foreground.

Both items in the menu display three dots at the end because this is default macOS behavior to indicate that this menu item opens a new window.

Also this PR adds the functionality to reopen the main window on dock app icon click.

1. Opens the main window if the window is not opened currently and the user clicks on the dock icon. This also is default macOS behavior. 