### PR TITLE
Sorting preparation

### DIFF
--- a/BuildStatusChecker/Sources/BuildStatusChecker/Model/Builds.swift
+++ b/BuildStatusChecker/Sources/BuildStatusChecker/Model/Builds.swift
@@ -47,7 +47,6 @@ public class Builds {
             }
         }
         else {
-            debugPrint("Builds of branches with name %{PUBLIC}@ will be ignored.")
             os_log("Builds of branches with name %{PUBLIC}@ will be ignored.", log: OSLog.builds, type: .info, build.branch)
         }
     }

--- a/Lumina/Modules/BuildMonitor/View/BuildMonitorView.swift
+++ b/Lumina/Modules/BuildMonitor/View/BuildMonitorView.swift
@@ -18,14 +18,9 @@ struct BuildMonitorView: View {
                 }
 
                 viewModel.errorMessage.map { ErrorView(message: $0) }
-               
-                viewModel.development.map { BuildView(viewModel: BuildViewModel(from: $0)) }
-                viewModel.master.map { BuildView(viewModel: BuildViewModel(from: $0)) }
-                viewModel.release.map { BuildView(viewModel: BuildViewModel(from: $0)) }
-                viewModel.hotfix.map { BuildView(viewModel: BuildViewModel(from: $0)) }
 
-                ForEach(viewModel.feature, id: \.self) { featureBuild in
-                    BuildView(viewModel: BuildViewModel(from: featureBuild))
+                ForEach(builds, id: \.self) { build in
+                    BuildView(viewModel: BuildViewModel(from: build))
                 }
 
                 Spacer()
@@ -34,6 +29,13 @@ struct BuildMonitorView: View {
             .padding(.trailing, 15)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+    }
+    
+    private var builds: [Build] {
+        var builds = [viewModel.development, viewModel.master, viewModel.release, viewModel.hotfix]
+        builds.append(contentsOf: viewModel.feature)
+        return builds
+            .compactMap { $0 }
     }
 }
 


### PR DESCRIPTION
This cleans some of the code and also makes it possible to introduce various sorting options. To change the sort order of the displayed builds, one only needs to call sorted(by:) on the new builds array property.

In order to resolve #4 and #16 this probably will be a necessary step.