### PR TITLE
Feature: Copy build number

### DIFF
--- a/BuildStatusChecker/Sources/BuildStatusChecker/API/Bitrise/BitriseAPI.swift
+++ b/BuildStatusChecker/Sources/BuildStatusChecker/API/Bitrise/BitriseAPI.swift
@@ -82,7 +82,6 @@ extension BitriseAPI {
 
         let publisher = URLSession.shared.dataTaskPublisher(for: urlRequest)
         .map {
-            let text = String(data: $0.data, encoding: .utf8)
             if let dict = try? JSONSerialization.jsonObject(with: $0.data, options: []) as? [String: Any] {
                 debugPrint(dict)
             }

--- a/BuildStatusChecker/Sources/BuildStatusChecker/API/Bitrise/BitriseBuild.swift
+++ b/BuildStatusChecker/Sources/BuildStatusChecker/API/Bitrise/BitriseBuild.swift
@@ -54,7 +54,11 @@ public struct BitriseBuild: Codable {
     }
 
     var groupId: String {
-        "\(commitHash)_\(parentBuildNumber ?? buildNumber)"
+        if let commitHash = commitHash {
+            return "\(commitHash)_\(parentBuildNumber ?? buildNumber)"
+        } else {
+            return "\(parentBuildNumber ?? buildNumber)"
+        }
     }
 
     var info: String {

--- a/Lumina/Modules/BuildMonitor/View/BuildView.swift
+++ b/Lumina/Modules/BuildMonitor/View/BuildView.swift
@@ -46,6 +46,13 @@ struct BuildView: View {
         .background(viewModel.backgroundColor)
         .cornerRadius(15)
         .opacity(opacity)
+        .contextMenu(menuItems: {
+            Button(action: self.copyBuildNumber) {
+                // replace with Label once macOS 11.0 is the min. deployment target
+                // Label("Copy Build Number", systemImage: "number")
+                Text("Copy Build Number")
+            }
+        })
         .onTapGesture {
             self.viewModel.openInBrowser()
         }
@@ -54,6 +61,12 @@ struct BuildView: View {
                 withAnimation(self.repeatingAnimation) { self.opacity = 0.5 }
             }
         }
+    }
+    
+    private func copyBuildNumber() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString("#\(viewModel.build.buildNumber)", forType: .string)
     }
 }
 


### PR DESCRIPTION
This adds a context menu (invoked via right-click) to the build monitor view to be able to copy the build number to the clipboard.

I also fixed some warnings Xcode showed me. Let me know if you would like to keep these changes separate from this PR.